### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ChrisHicks0968/974bc8cf-2960-43d8-9907-b64b0f7779e5/3c375158-135d-42e8-8f35-b3dd62111cfb/_apis/work/boardbadge/34fb762c-d26d-4757-895c-8205d41f0da2)](https://dev.azure.com/ChrisHicks0968/974bc8cf-2960-43d8-9907-b64b0f7779e5/_boards/board/t/3c375158-135d-42e8-8f35-b3dd62111cfb/Microsoft.RequirementCategory)
 # IssuesTest


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ChrisHicks0968/974bc8cf-2960-43d8-9907-b64b0f7779e5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.